### PR TITLE
process-win: add 2 threads (stdout collector, stderr collector)

### DIFF
--- a/src/process-win.cpp
+++ b/src/process-win.cpp
@@ -120,8 +120,9 @@ auto Process::collect_outputs() -> bool {
                     // finished the main process
                     break;
                 }
-                if(on_stdout) {
-                    on_stdout({buf.data(), size_t(len)});
+                auto callback = i == 0 ? on_stdout : on_stderr;
+                if(callback) {
+                    callback({buf.data(), size_t(len)});
                 }
             }
         });

--- a/src/process-win.cpp
+++ b/src/process-win.cpp
@@ -132,7 +132,7 @@ auto Process::collect_outputs() -> bool {
         const auto wait_process = WaitForSingleObject(process_handle, INFINITE);
         if(wait_process == WAIT_OBJECT_0) {
             status   = Status::Finished;
-            auto buf = std::array<char, 1>{' '};
+            auto buf = std::array{' '};
             auto len = DWORD();
             assert_b(WriteFile(pipes[1].input, buf.data(), buf.size(), &len, NULL) == TRUE, "failed to write to the child process. GetLastError: ", GetLastError());
             assert_b(WriteFile(pipes[2].input, buf.data(), buf.size(), &len, NULL) == TRUE, "failed to write to the child process. GetLastError: ", GetLastError());


### PR DESCRIPTION
The previous implementation was called WaitForSingleObject infinite with no timeout, so it drained CPU power.  
So I change the WaitForSingleObject for the process_handle to INFINITE and create 2 threads to collect stdout and stderr independently.
The collector process can detect the end of the main process by checking the status. 
But the collector process cannot check the status while no data is reaching the ReadFile buffer. 
So I implemented that the main process of process-win sends an empty space to the stdout and stderr collector threads by using WriteFile. 